### PR TITLE
Removed libglapi (Fedora 42 fix)

### DIFF
--- a/configs/toolchain-llvm-18.json
+++ b/configs/toolchain-llvm-18.json
@@ -68,14 +68,14 @@
         "fedora": {
           "cmds": [
             "sudo dnf -y update",
-            "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libglapi mesa-libxatracker",
+            "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libxatracker",
             "sudo dnf -y install llvm-devel clang clang-tools-extra lldb lld libcxx-devel libcxx-static libcxxabi-devel libcxxabi-static"
           ]
         },
         "rhel": {
           "cmds": [
             "sudo dnf -y update",
-            "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libglapi mesa-libxatracker",
+            "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libxatracker",
             "sudo dnf -y install llvm-devel clang clang-tools-extra lldb lld"
           ]
         }


### PR DESCRIPTION
Fixes compilation on Fedora 42.

Removed `mesa-libglapi` from dependencies on Fedora/RHEL.

The package doesn't exist from Mesa v25, which is the default for Fedora 42 (and next release of RHEL).

For previous versions it's not a hard dependency and it compiles fine without, as it's pulled transitively by other packages as needed.