### PR TITLE
Always use llvm18 on Fedora

### DIFF
--- a/configs/toolchain-llvm-18.json
+++ b/configs/toolchain-llvm-18.json
@@ -69,7 +69,7 @@
           "cmds": [
             "sudo dnf -y update",
             "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libxatracker",
-            "sudo dnf -y install llvm-devel clang clang-tools-extra lldb lld libcxx-devel libcxx-static libcxxabi-devel libcxxabi-static"
+            "sudo dnf -y install llvm18-devel clang18 clang18-tools-extra lldb lld18 libcxx-devel libcxx-static libcxxabi-devel libcxxabi-static"
           ]
         },
         "rhel": {

--- a/configs/toolchain-llvm-18.json
+++ b/configs/toolchain-llvm-18.json
@@ -14,7 +14,6 @@
   ],
   "type": "toolchain",
   "toolchain": "llvm",
-  "prefer_llvm": "18",
   "env": {
     "VERSION": "18",
     "NONINTERACTIVE": "1"
@@ -69,7 +68,7 @@
           "cmds": [
             "sudo dnf -y update",
             "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libxatracker",
-            "sudo dnf -y install llvm18-devel clang18 clang18-tools-extra lldb lld18 libcxx-devel libcxx-static libcxxabi-devel libcxxabi-static"
+            "sudo dnf -y install llvm${VERSION}-devel clang${VERSION} clang${VERSION}-tools-extra lldb lld${VERSION} libcxx-devel libcxx-static libcxxabi-devel libcxxabi-static"
           ]
         },
         "rhel": {

--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -2081,12 +2081,20 @@ def setup_toolchain(platform_, git_token, cookie_file, plex, enable, disable, en
         return
 
     if platform_['toolchain'] == 'llvm':
-        prefer_llvm = os.environ.get('PREFER_LLVM', '18')
+        prefer_llvm = os.environ.get('PREFER_LLVM', None)
         if not prefer_llvm:
-            if 'prefer_llvm' in platform_:
-                prefer_llvm = platform_['prefer_llvm']
+            # If not set by ENV variable, get default from platform config
+            if 'VERSION' in platform_['env']:
+                prefer_llvm = platform_['env']['VERSION']
                 os.environ['PREFER_LLVM'] = prefer_llvm
                 print(f'PREFER_LLVM: {prefer_llvm}')
+        else:
+            # If manually set by user, override the platform config
+            platform_['env']['VERSION'] = prefer_llvm
+
+        # Failsafe
+        if not prefer_llvm:
+            sys.exit("PREFER_LLVM is not set and no prefer_llvm key present in toolchain config")
 
         host_type = get_host_type()
 
@@ -2507,10 +2515,10 @@ export CC=''' + os.environ.get('CC', 'clang') + '''
 export CXX=''' + os.environ.get('CXX', 'clang++') + '''
 export LLVM_CONFIG=''' + os.environ.get('LLVM_CONFIG', 'llvm-config') + '''
 export LLVM_PREFIX=''' + os.environ.get('LLVM_PREFIX', '/usr') + '''
-export LLVM_VERSION=''' + os.environ.get('LLVM_VERSION', '18') + '''
-export LLVM_CMAKEDIR=''' + os.environ.get('LLVM_CMAKEDIR', '/usr/lib/llvm-18/cmake') + '''
+export LLVM_VERSION=''' + os.environ.get('LLVM_VERSION', '') + '''
+export LLVM_CMAKEDIR=''' + os.environ.get('LLVM_CMAKEDIR', '') + '''
 export LLVM_STRIP=''' + os.environ.get('LLVM_STRIP', '/usr/bin/llvm-strip') + '''
-export PREFER_LLVM=''' + os.environ.get('PREFER_LLVM', '18') + '''
+export PREFER_LLVM=''' + os.environ.get('PREFER_LLVM', '') + '''
 # (alias clang tools to match version)
 alias clang=clang-${LLVM_VERSION}
 alias clang++=clang++-${LLVM_VERSION}

--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -338,11 +338,6 @@ def main():
     get_flutter_engine_runtime(clean_workspace, get_flutter_arch())
 
     #
-    # Create environmental setup script
-    #
-    write_env_script_header(workspace)
-
-    #
     # Setup Platform(s)
     #
     github_token = globals_.get('github_token')
@@ -355,6 +350,11 @@ def main():
 
     setup_platforms(platforms, github_token, cookie_file, args.plex, args.enable, args.disable, args.enable_plugin,
                     args.disable_plugin, app_folder)
+
+    #
+    # Create environmental setup script
+    #
+    write_env_script_header(workspace)
 
     #
     # Display the custom devices list
@@ -2081,7 +2081,7 @@ def setup_toolchain(platform_, git_token, cookie_file, plex, enable, disable, en
         return
 
     if platform_['toolchain'] == 'llvm':
-        prefer_llvm = os.environ.get('PREFER_LLVM', None)
+        prefer_llvm = os.environ.get('PREFER_LLVM', '18')
         if not prefer_llvm:
             if 'prefer_llvm' in platform_:
                 prefer_llvm = platform_['prefer_llvm']
@@ -2501,6 +2501,22 @@ cd \"$( dirname -- \"$SCRIPT_PATH\"; )\" > '/dev/null'
 SCRIPT_PATH=\"$( pwd; )\"
 popd  > '/dev/null'
 echo SCRIPT_PATH=$SCRIPT_PATH
+
+# LLVM/Clang environment variables
+export CC=''' + os.environ.get('CC', 'clang') + '''
+export CXX=''' + os.environ.get('CXX', 'clang++') + '''
+export LLVM_CONFIG=''' + os.environ.get('LLVM_CONFIG', 'llvm-config') + '''
+export LLVM_PREFIX=''' + os.environ.get('LLVM_PREFIX', '/usr') + '''
+export LLVM_VERSION=''' + os.environ.get('LLVM_VERSION', '18') + '''
+export LLVM_CMAKEDIR=''' + os.environ.get('LLVM_CMAKEDIR', '/usr/lib/llvm-18/cmake') + '''
+export LLVM_STRIP=''' + os.environ.get('LLVM_STRIP', '/usr/bin/llvm-strip') + '''
+export PREFER_LLVM=''' + os.environ.get('PREFER_LLVM', '18') + '''
+# (alias clang tools to match version)
+alias clang=clang-${LLVM_VERSION}
+alias clang++=clang++-${LLVM_VERSION}
+alias clang-tidy=${LLVM_PREFIX}/bin/clang-tidy
+alias clang-format=${LLVM_PREFIX}/bin/clang-format
+alias llvm-config=${LLVM_CONFIG}
 
 export FLUTTER_WORKSPACE=$SCRIPT_PATH
 export PATH=$FLUTTER_WORKSPACE/flutter/bin:$PATH


### PR DESCRIPTION
This PR fixes all possible issues with LLVM/clang version mismatch on more recent Fedora versions 💖 
Now, akin to its Ubuntu counterpart, it will always install `llvm18` and configure the workspace to use it exclusively.

Summary of changes:
- `llvm18`, `clang18` and other related tools are now explicitly installed (instead of whatever is latest according to the OS)
- In `flutter_workspace.py` the `PREFER_LLVM` envvar will default to `18`, making sure the right version of `llvm-config` is always called (including subsequent settings
`CC`/`CXX`/etc as well as `clang/format/tidy/...` are now set in `setup-env.sh` and the correct versions are always used workspace-wide
- `setup-env.sh` also configures the necessary aliases