### PR TITLE
Updated CI platform build configs

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -1,8 +1,12 @@
-name: fedora-workspace-automation
+name: fedora
 
 on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
+    paths-ignore:
+      - .github/workflows/macos.yaml
+      - .github/workflows/ubuntu.yml
+      - .github/workflows/windows.yaml
   release:
     types: [ published, created, edited ]
   workflow_dispatch:
@@ -11,7 +15,7 @@ on:
     - cron:  '0 0 * * *'
 
 jobs:
-  workspace-automation:
+  run:
     strategy:
       matrix:
         os: [fedora:42]
@@ -20,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.os }}
+
+    if: "!contains(github.event.head_commit.message, '[skip fedora]')"
 
     steps:
       - name: Set up tools

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - .github/workflows/windows.yaml
       - .github/workflows/ubuntu.yml
+      - .github/workflows/fedora.yml
   release:
     types: [ published, created, edited ]
   workflow_dispatch:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,4 +1,4 @@
-name: macos-workspace-automation
+name: macos
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ on:
 
 jobs:
 
-  workspace-automation:
+  run:
 
     env:
       NONINTERACTIVE: 1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
     paths-ignore:
-      - .github/workflows/fedora.yml
+      - .github/workflows/windows.yaml
+      - .github/workflows/ubuntu.yml
   release:
     types: [ published, created, edited ]
   workflow_dispatch:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -27,6 +27,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    if: "!contains(github.event.head_commit.message, '[skip macos]')"
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - .github/workflows/macos.yaml
       - .github/workflows/windows.yaml
+      - .github/workflows/fedora.yml
   release:
     types: [ published, created, edited ]
   workflow_dispatch:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,6 +23,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    if: "!contains(github.event.head_commit.message, '[skip ubuntu]')"
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: ubuntu-workspace-automation
+name: ubuntu
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ on:
 
 jobs:
 
-  workspace-automation:
+  run:
 
     strategy:
       matrix:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
     paths-ignore:
-      - .github/workflows/fedora.yml
+      - .github/workflows/macos.yaml
+      - .github/workflows/windows.yaml
   release:
     types: [ published, created, edited ]
   workflow_dispatch:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,4 +1,4 @@
-name: windows-workspace-automation
+name: windows
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ on:
 
 jobs:
 
-  workspace-automation:
+  run:
 
     env:
       NONINTERACTIVE: 1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,6 +27,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    if: "!contains(github.event.head_commit.message, '[skip windows]')"
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
     paths-ignore:
-      - .github/workflows/fedora.yml
+      - .github/workflows/macos.yaml
+      - .github/workflows/ubuntu.yml
   release:
     types: [ published, created, edited ]
   workflow_dispatch:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - .github/workflows/macos.yaml
       - .github/workflows/ubuntu.yml
+      - .github/workflows/fedora.yml
   release:
     types: [ published, created, edited ]
   workflow_dispatch:


### PR DESCRIPTION
- **Added platform-specific exclusions**: Windows/macOS will skip builds if ONLY Ubuntu CI config changed, etc. Only PR builds are affected by this. Release/schedule/dispatch runs will build everything, like before. Very useful when shipping CI-relative PRs
- **Renamed jobs**: a readability improvement, now they match the filenames for their respective configs
  before `workspace-automation/macos-workspace-automation/workspace-automation`
  now     : `workspace-automation/macos/run`
  (example below)