### PR TITLE
Move env script header before platform setup

### DIFF
--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -348,13 +348,15 @@ def main():
     if args.cookie_file:
         cookie_file = args.cookie_file
 
-    setup_platforms(platforms, github_token, cookie_file, args.plex, args.enable, args.disable, args.enable_plugin,
-                    args.disable_plugin, app_folder)
-
     #
     # Create environmental setup script
     #
     write_env_script_header(workspace)
+
+
+    setup_platforms(platforms, github_token, cookie_file, args.plex, args.enable, args.disable, args.enable_plugin,
+                    args.disable_plugin, app_folder)
+
 
     #
     # Display the custom devices list


### PR DESCRIPTION
We did overwrite the platform parts of the env-file with the header. Reorder.