### PR TITLE
Toolchain paths fix (linux)

### DIFF
--- a/configs/toolchain-common-cmake.json
+++ b/configs/toolchain-common-cmake.json
@@ -18,6 +18,10 @@
     "env": {
         "VERSION": "3.31"
     },
+    "append_to_runtime_env": [
+        "# toolchain-common-cmake",
+        "export PATH=$FLUTTER_WORKSPACE/.config/flutter_workspace/toolchain-common-cmake/bin:$PATH"
+    ],
     "runtime": {
         "artifacts": {
             "http": {

--- a/configs/toolchain-common-cmake.json
+++ b/configs/toolchain-common-cmake.json
@@ -18,10 +18,16 @@
     "env": {
         "VERSION": "3.31"
     },
-    "append_to_runtime_env": [
-        "# toolchain-common-cmake",
-        "export PATH=$FLUTTER_WORKSPACE/.config/flutter_workspace/toolchain-common-cmake/bin:$PATH"
-    ],
+    "append_to_runtime_env": {
+        "common": [
+            "# toolchain-common-cmake",
+            "export PATH=$FLUTTER_WORKSPACE/.config/flutter_workspace/toolchain-common-cmake/bin:$PATH"
+        ],
+        "windows": [
+            "# toolchain-common-cmake",
+            "$env:PATH = \"$env:FLUTTER_WORKSPACE\\.config\\flutter_workspace\\toolchain-common-cmake\\bin;$env:PATH\""
+        ]
+    },
     "runtime": {
         "artifacts": {
             "http": {

--- a/configs/toolchain-common-ninja.json
+++ b/configs/toolchain-common-ninja.json
@@ -19,10 +19,16 @@
         "VERSION": "1.12.1",
         "ARCHIVE_FILE": "ninja-${VERSION}.zip"
     },
-    "append_to_runtime_env": [
-        "# toolchain-common-cmake",
-        "export PATH=$FLUTTER_WORKSPACE/.config/flutter_workspace/toolchain-common-ninja:$PATH"
-    ],
+    "append_to_runtime_env": {
+        "common": [
+            "# toolchain-common-ninja",
+            "export PATH=$FLUTTER_WORKSPACE/.config/flutter_workspace/toolchain-common-ninja:$PATH"
+        ],
+        "windows": [
+            "# toolchain-common-ninja",
+            "$env:PATH = \"$env:FLUTTER_WORKSPACE\\.config\\flutter_workspace\\toolchain-common-ninja;$env:PATH\""
+        ]
+    },
     "runtime": {
         "artifacts": {
             "http": {

--- a/configs/toolchain-common-ninja.json
+++ b/configs/toolchain-common-ninja.json
@@ -19,6 +19,10 @@
         "VERSION": "1.12.1",
         "ARCHIVE_FILE": "ninja-${VERSION}.zip"
     },
+    "append_to_runtime_env": [
+        "# toolchain-common-cmake",
+        "export PATH=$FLUTTER_WORKSPACE/.config/flutter_workspace/toolchain-common-ninja:$PATH"
+    ],
     "runtime": {
         "artifacts": {
             "http": {

--- a/configs/toolchain-llvm.json
+++ b/configs/toolchain-llvm.json
@@ -18,13 +18,15 @@
     "DEFAULT_VERSION": "18",
     "NONINTERACTIVE": "1"
   },
-  "append_to_runtime_env": [
-    "# toolchain-llvm",
-    "export PREFER_LLVM=${PREFER_LLVM}",
-    "export LLVM_BINDIR='${LLVM_BINDIR}'",
-    "\n",
-    "export PATH=$LLVM_BINDIR:$PATH"
-  ],
+  "append_to_runtime_env": {
+      "common": [
+        "# toolchain-llvm",
+        "export PREFER_LLVM=${PREFER_LLVM}",
+        "export LLVM_BINDIR='${LLVM_BINDIR}'",
+        "\n",
+        "export PATH=$LLVM_BINDIR:$PATH"
+      ]
+  },
   "runtime": {
     "pre-requisites": {
       "aarch64": {

--- a/configs/toolchain-llvm.json
+++ b/configs/toolchain-llvm.json
@@ -80,9 +80,7 @@
           "cmds": [
             "sudo dnf -y update",
             "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libxatracker",
-            "export VV=${PREFER_LLVM}",
-            "CURRENT_LLVM=$(dnf info llvm 2>/dev/null | awk '/^Version/ {print $3;exit}' | cut -d. -f1); if [[ $CURRENT_LLVM == $PREFER_LLVM ]]; then export VV=''; fi",
-            "echo $VV > .llvm-version",
+            "export VV=${PREFER_LLVM}; CURRENT_LLVM=$(dnf info llvm 2>/dev/null | awk '/^Version/ {print $3;exit}' | cut -d. -f1); if [[ $CURRENT_LLVM == $PREFER_LLVM ]]; then export VV=''; fi; echo $VV > .llvm-version",
             "echo \"Installing LLVM version $(cat .llvm-version)\"",
             "VV=$(cat .llvm-version); if [[ -n $VV ]]; then sudo dnf copr enable @fedora-llvm-team/llvm${PREFER_LLVM} -y; fi",
             "VV=$(cat .llvm-version); sudo dnf -y install llvm${VV}-devel clang${VV} clang${VV}-tools-extra lldb lld${VV} libcxx-devel libcxx-static libcxxabi-devel libcxxabi-static",

--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -2140,12 +2140,11 @@ def setup_toolchain(platform_, git_token, cookie_file, plex, enable, disable, en
                 return
 
     elif platform_['toolchain'] == 'common':
-        # do nothing
-        print('')
+        pass
     else:
         print_banner("Toolchain not supported")
 
-    # append lines to runtime env script
+    # append lines to runtime env script (for both llvm and common toolchains)
     workspace = os.environ.get('FLUTTER_WORKSPACE')
     if 'append_to_runtime_env' in platform_:
         append_to_runtime_env = platform_['append_to_runtime_env']

--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -2111,19 +2111,20 @@ def setup_toolchain(platform_, git_token, cookie_file, plex, enable, disable, en
         return
     platform_['type'] = 'toolchain'
 
-    if platform_['toolchain'] == 'llvm':
-        host_type = get_host_type()
+    host_type = get_host_type()
+    if host_type == 'linux':
+        host_type = get_freedesktop_os_release_id()
 
+
+    if platform_['toolchain'] == 'llvm':
         llvm_base_path = '/usr'
 
         if host_type == 'darwin':
             llvm_base_path = get_mac_brew_prefix('llvm' + '@' + prefer_llvm)
-        elif host_type == 'linux':
-            host_type = get_freedesktop_os_release_id()
-            if host_type == 'ubuntu':
-                llvm_base_path = '/usr/lib/llvm-' + prefer_llvm + '/bin'
-            elif host_type == 'fedora':
-                llvm_base_path = '/usr/lib64/llvm' + prefer_llvm + '/bin'
+        elif host_type == 'ubuntu':
+            llvm_base_path = '/usr/lib/llvm-' + prefer_llvm + '/bin'
+        elif host_type == 'fedora':
+            llvm_base_path = '/usr/lib64/llvm' + prefer_llvm + '/bin'
 
         print(f'Looking for llvm-config in {llvm_base_path}')
         llvm_config = get_first_file_in_path(llvm_base_path, 'llvm-config')
@@ -2144,14 +2145,20 @@ def setup_toolchain(platform_, git_token, cookie_file, plex, enable, disable, en
     else:
         print_banner("Toolchain not supported")
 
+    # get host type and check if present in platform_['append_to_runtime_env'], if not attempt to use common
+    if host_type in platform_['append_to_runtime_env']:
+        append_to_runtime_env = platform_['append_to_runtime_env'][host_type]
+    elif 'common' in platform_['append_to_runtime_env']:
+        append_to_runtime_env = platform_['append_to_runtime_env']['common']
+    else:
+        append_to_runtime_env = []
+
     # append lines to runtime env script (for both llvm and common toolchains)
     workspace = os.environ.get('FLUTTER_WORKSPACE')
-    if 'append_to_runtime_env' in platform_:
-        append_to_runtime_env = platform_['append_to_runtime_env']
-        if append_to_runtime_env:
-            append_to_env_script(workspace, '\n')
-            for line in append_to_runtime_env:
-                append_to_env_script(workspace, line)
+    if append_to_runtime_env:
+        append_to_env_script(workspace, '\n')
+        for line in append_to_runtime_env:
+            append_to_env_script(workspace, line)
 
 
 def get_toolchains(platforms):

--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -2139,19 +2139,20 @@ def setup_toolchain(platform_, git_token, cookie_file, plex, enable, disable, en
                 exit()
                 return
 
-        # append lines to runtime env script
-        workspace = os.environ.get('FLUTTER_WORKSPACE')
-        if 'append_to_runtime_env' in platform_:
-            append_to_runtime_env = platform_['append_to_runtime_env']
-            if append_to_runtime_env:
-                append_to_env_script(workspace, '\n')
-                for line in append_to_runtime_env:
-                    append_to_env_script(workspace, line)
-
     elif platform_['toolchain'] == 'common':
-        return
+        # do nothing
+        print('')
     else:
         print_banner("Toolchain not supported")
+
+    # append lines to runtime env script
+    workspace = os.environ.get('FLUTTER_WORKSPACE')
+    if 'append_to_runtime_env' in platform_:
+        append_to_runtime_env = platform_['append_to_runtime_env']
+        if append_to_runtime_env:
+            append_to_env_script(workspace, '\n')
+            for line in append_to_runtime_env:
+                append_to_env_script(workspace, line)
 
 
 def get_toolchains(platforms):


### PR DESCRIPTION
Fixes some toolchain issues on workspace init:

- On Fedora, LLVM would ignore `PREFER_LLVM` and always install latest OS default instead
- On Linux, `cmake` and `ninja` were not included in the `setup_env.sh` path, causing them to work during the initial build but never after

Technically this should also remove the requirement of having CMake/Ninja as pre-workspace dependencies