### PR TITLE
Fixes LLVM installation stuck on Fedora (interactive)

### DIFF
--- a/configs/toolchain-llvm.json
+++ b/configs/toolchain-llvm.json
@@ -82,7 +82,7 @@
           "cmds": [
             "sudo dnf -y update",
             "sudo dnf -y install libxkbcommon-devel wayland-devel wayland-protocols-devel mesa-dri-drivers mesa-filesystem mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libgbm-devel mesa-libxatracker",
-            "export VV=${PREFER_LLVM}; CURRENT_LLVM=$(dnf info llvm 2>/dev/null | awk '/^Version/ {print $3;exit}' | cut -d. -f1); if [[ $CURRENT_LLVM == $PREFER_LLVM ]]; then export VV=''; fi; echo $VV > .llvm-version",
+            "export VV=${PREFER_LLVM}; CURRENT_LLVM=$(dnf -y info llvm 2>/dev/null | awk '/^Version/ {print $3;exit}' | cut -d. -f1); if [[ $CURRENT_LLVM == $PREFER_LLVM ]]; then export VV=''; fi; echo $VV > .llvm-version",
             "echo \"Installing LLVM version $(cat .llvm-version)\"",
             "VV=$(cat .llvm-version); if [[ -n $VV ]]; then sudo dnf copr enable @fedora-llvm-team/llvm${PREFER_LLVM} -y; fi",
             "VV=$(cat .llvm-version); sudo dnf -y install llvm${VV}-devel clang${VV} clang${VV}-tools-extra lldb lld${VV} libcxx-devel libcxx-static libcxxabi-devel libcxxabi-static",


### PR DESCRIPTION
It would hang until Return is pressed on one of the commands in interactive mode - doesn't affect CI

Fedora only