### PR TITLE
[fluorite] Fixes AMD iGPU SEGFAULT

### DIFF
--- a/configs/filament-v1.65.2.json
+++ b/configs/filament-v1.65.2.json
@@ -69,7 +69,8 @@
                     "git apply ${PATCH_FOLDER}/filament/0002-install-required-files.patch",
                     "git apply ${PATCH_FOLDER}/filament/0003-move-include-contents-to-include-filament.patch",
                     "git apply ${PATCH_FOLDER}/filament/0004-move-libraries-so-they-install-1.65.2.patch",
-                    "git apply ${PATCH_FOLDER}/filament/0005-spirv-tools-threads.patch"
+                    "git apply ${PATCH_FOLDER}/filament/0005-spirv-tools-threads.patch",
+                    "git apply ${PATCH_FOLDER}/filament/0007-fix-min-vulkan-api-version-1.65.2.patch"
                 ]
             },
             {

--- a/patches/filament/0007-fix-min-vulkan-api-version-1.65.2.patch
+++ b/patches/filament/0007-fix-min-vulkan-api-version-1.65.2.patch
@@ -1,0 +1,13 @@
+diff --git a/filament/backend/src/vulkan/VulkanConstants.h b/filament/backend/src/vulkan/VulkanConstants.h
+index 2c92277..0dcbb30 100644
+--- a/filament/backend/src/vulkan/VulkanConstants.h
++++ b/filament/backend/src/vulkan/VulkanConstants.h
+@@ -190,7 +190,7 @@ static_assert(FVK_ENABLED(FVK_DEBUG_VALIDATION));
+ constexpr struct VkAllocationCallbacks* VKALLOC = nullptr;
+ 
+ constexpr static const int FVK_REQUIRED_VERSION_MAJOR = 1;
+-constexpr static const int FVK_REQUIRED_VERSION_MINOR = 1;
++constexpr static const int FVK_REQUIRED_VERSION_MINOR = 3;
+ 
+ // Maximum number of VkCommandBuffer handles managed simultaneously by VulkanCommands.
+ //


### PR DESCRIPTION
Relates to:
- https://github.com/toyota-connected/fluorite/issues/1

Tentative fix to SEGFAULT crashes when creating VBOs for meshes on AMD iGPU in [toyota-connected/fluorite](https://github.com/toyota-connected/fluorite)

@jwinarske Needs testing on following devices:
- AMD Ryzen 9 + AMD Radeon Graphics