### PR TITLE
Remove fedora-40 from fedora CI matrix

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -19,7 +19,7 @@ jobs:
   run:
     strategy:
       matrix:
-        os: [fedora:40, fedora:41, fedora:42, fedora:43]
+        os: [fedora:41, fedora:42, fedora:43]
 
     # NOTE: GitHub Actions does not support running on Fedora directly, so we run it in a container.
     runs-on: ubuntu-latest


### PR DESCRIPTION
-fedora 40 is no longer supported
-resolves https://github.com/meta-flutter/workspace-automation/issues/136