### PR TITLE
flutter-engine

### DIFF
--- a/configs/flutter-engine-deprecated.json
+++ b/configs/flutter-engine-deprecated.json
@@ -1,5 +1,5 @@
 {
-    "id": "flutter-engine-mono",
+    "id": "flutter-engine-deprecated",
     "load": false,
     "supported_archs": [
         "aarch64",
@@ -15,24 +15,23 @@
         "PATH": "${FLUTTER_WORKSPACE}/app/depot_tools:${PATH}",
         "RUNTIME_MODE": "debug",
         "DEPOT_TOOLS": "${FLUTTER_WORKSPACE}/app/depot_tools",
-        "ENGINE_ROOT": "${FLUTTER_WORKSPACE}/flutter",
+        "ENGINE_ROOT": "${FLUTTER_WORKSPACE}/app/engine",
         "VPYTHON_VIRTUALENV_ROOT": "${ENGINE_ROOT}/.vpython",
-        "ENGINE_SRC_DIR_RELATIVE": "engine/src",
+        "ENGINE_SRC_DIR_RELATIVE": "src",
         "ENGINE_SRC_DIR": "${ENGINE_ROOT}/${ENGINE_SRC_DIR_RELATIVE}",
-        "ENGINE_BUILD_FLAGS": "--unoptimized --runtime-mode=${RUNTIME_MODE} --no-prebuilt-dart-sdk --embedder-for-target --enable-fontconfig --disable-desktop-embeddings --no-build-embedder-examples --enable-impeller-3d --no-lto --no-goma --no-rbe --no-stripped --no-enable-unittests",
-        "ENGINE_BUILD_DIR": "${ENGINE_SRC_DIR}/out/host_debug_unopt",
+        "ENGINE_BUILD_FLAGS": "--runtime-mode=${RUNTIME_MODE} --embedder-for-target --enable-fontconfig --disable-desktop-embeddings --no-build-embedder-examples --enable-impeller-3d --no-lto --no-goma --no-rbe --no-stripped --no-enable-unittests",
+        "ENGINE_BUILD_DIR": "${ENGINE_SRC_DIR}/out/host_debug",
         "GN_ARGS_FILE": "${ENGINE_BUILD_DIR}/args.gn",
         "GN_ARGS_APPEND": "",
-        "PATCH_FOLDER": "${FLUTTER_WORKSPACE}/patches/flutter-engine-mono"
+        "PATCH_FOLDER": "${FLUTTER_WORKSPACE}/patches/flutter-engine-deprecated"
     },
     "src": [],
     "runtime": {
         "gclient_config": {
             "path": "${ENGINE_ROOT}",
             "managed": false,
-            "name": ".",
-            "url": "https://github.com/flutter/flutter.git",
-            "custom_deps": {},
+            "name": "src/flutter",
+            "url": "https://github.com/flutter/engine.git",
             "custom_vars": {
                 "download_android_deps": false,
                 "download_windows_deps": false,
@@ -74,7 +73,7 @@
             {
                 "cwd": "${ENGINE_ROOT}",
                 "cmds": [
-                    "gclient sync -D -R -j${HARDWARE_THREADS} -v"
+                    "gclient sync -D -R --revision ${FLUTTER_ENGINE_VERSION} -j${HARDWARE_THREADS} -v"
                 ]
             },
             {

--- a/configs/flutter-engine.json
+++ b/configs/flutter-engine.json
@@ -15,12 +15,12 @@
         "PATH": "${FLUTTER_WORKSPACE}/app/depot_tools:${PATH}",
         "RUNTIME_MODE": "debug",
         "DEPOT_TOOLS": "${FLUTTER_WORKSPACE}/app/depot_tools",
-        "ENGINE_ROOT": "${FLUTTER_WORKSPACE}/app/engine",
+        "ENGINE_ROOT": "${FLUTTER_WORKSPACE}/flutter",
         "VPYTHON_VIRTUALENV_ROOT": "${ENGINE_ROOT}/.vpython",
-        "ENGINE_SRC_DIR_RELATIVE": "src",
+        "ENGINE_SRC_DIR_RELATIVE": "engine/src",
         "ENGINE_SRC_DIR": "${ENGINE_ROOT}/${ENGINE_SRC_DIR_RELATIVE}",
-        "ENGINE_BUILD_FLAGS": "--runtime-mode=${RUNTIME_MODE} --embedder-for-target --enable-fontconfig --disable-desktop-embeddings --no-build-embedder-examples --enable-impeller-3d --no-lto --no-goma --no-rbe --no-stripped --no-enable-unittests",
-        "ENGINE_BUILD_DIR": "${ENGINE_SRC_DIR}/out/host_debug",
+        "ENGINE_BUILD_FLAGS": "--unoptimized --runtime-mode=${RUNTIME_MODE} --no-prebuilt-dart-sdk --embedder-for-target --enable-fontconfig --disable-desktop-embeddings --no-build-embedder-examples --no-lto --no-goma --no-rbe --no-stripped --no-enable-unittests",
+        "ENGINE_BUILD_DIR": "${ENGINE_SRC_DIR}/out/host_debug_unopt",
         "GN_ARGS_FILE": "${ENGINE_BUILD_DIR}/args.gn",
         "GN_ARGS_APPEND": "",
         "PATCH_FOLDER": "${FLUTTER_WORKSPACE}/patches/flutter-engine"
@@ -30,8 +30,9 @@
         "gclient_config": {
             "path": "${ENGINE_ROOT}",
             "managed": false,
-            "name": "src/flutter",
-            "url": "https://github.com/flutter/engine.git",
+            "name": ".",
+            "url": "https://github.com/flutter/flutter.git",
+            "custom_deps": {},
             "custom_vars": {
                 "download_android_deps": false,
                 "download_windows_deps": false,
@@ -64,22 +65,42 @@
         },
         "post_cmds": [
             {
+                "cwd": "${ENGINE_ROOT}",
+                "cmds": [
+                    "gclient sync -R --jobs=${HARDWARE_THREADS}"
+                ]
+            },
+            {
                 "cwd": "${ENGINE_SRC_DIR}",
                 "cmds": [
                     "git reset --hard",
-                    "git apply ${PATCH_FOLDER}/0001-clang-toolchain.patch"
+                    "git apply ${PATCH_FOLDER}/0001-clang-toolchain.patch",
+                    "git apply ${PATCH_FOLDER}/0002-fml-build-config-add-riscv.patch",
+                    "git apply ${PATCH_FOLDER}/0003-gn-riscv32-and-riscv64.patch",
+                    "git apply ${PATCH_FOLDER}/0004-Add-risc-v-32-64-support-to-native-assets.patch",
+                    "git apply ${PATCH_FOLDER}/0005-tonic-riscv-support.patch"
                 ]
             },
             {
-                "cwd": "${ENGINE_ROOT}",
+                "cwd": "${ENGINE_SRC_DIR}/flutter/third_party/abseil-cpp",
                 "cmds": [
-                    "gclient sync -D -R --revision ${FLUTTER_ENGINE_VERSION} -j${HARDWARE_THREADS} -v"
+                    "git reset --hard",
+                    "git apply ${PATCH_FOLDER}/flutter/third_party/abseil-cpp/0001-flutter-third_party-abseil-cpp-clang-compiler-warnin.patch"
                 ]
             },
             {
-                "cwd": "${ENGINE_SRC_DIR}/flutter",
+                "cwd": "${ENGINE_SRC_DIR}/flutter/third_party/skia",
                 "cmds": [
-                    "git reset --hard"
+                    "git reset --hard",
+                    "git apply ${PATCH_FOLDER}/flutter/third_party/skia/0001-flutter-third_party-skia-memcpy-void-cast.patch"
+                ]
+            },
+            {
+                "cwd": "${ENGINE_SRC_DIR}/flutter/third_party/swiftshader",
+                "cmds": [
+                    "git reset --hard",
+                    "git apply ${PATCH_FOLDER}/flutter/third_party/swiftshader/0001-flutter-third_party-swiftshader-pointer-cast-to-void.patch",
+                    "git apply ${PATCH_FOLDER}/flutter/third_party/swiftshader/0002-flutter-third_party-swiftshader-llvm-16.0-required-f.patch"
                 ]
             },
             {

--- a/patches/flutter-engine-deprecated/0001-clang-toolchain.patch
+++ b/patches/flutter-engine-deprecated/0001-clang-toolchain.patch
@@ -1,17 +1,17 @@
-From 5e4bf78183f9bf30d093b3e766f36a5780f068ab Mon Sep 17 00:00:00 2001
+From eb564c8be13a16158056890069deef5bad533529 Mon Sep 17 00:00:00 2001
 From: Joel Winarske <joel.winarske@gmail.com>
-Date: Thu, 13 Feb 2025 12:44:11 -0800
+Date: Mon, 26 Aug 2024 12:25:58 -0700
 Subject: [PATCH] clang toolchain
 
 Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
 ---
- engine/src/build/toolchain/custom/BUILD.gn | 8 ++++----
+ build/toolchain/custom/BUILD.gn | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/engine/src/build/toolchain/custom/BUILD.gn b/engine/src/build/toolchain/custom/BUILD.gn
-index 3da5f93026..05de4d7e3c 100644
---- a/engine/src/build/toolchain/custom/BUILD.gn
-+++ b/engine/src/build/toolchain/custom/BUILD.gn
+diff --git a/build/toolchain/custom/BUILD.gn b/build/toolchain/custom/BUILD.gn
+index 3da5f93..05de4d7 100644
+--- a/build/toolchain/custom/BUILD.gn
++++ b/build/toolchain/custom/BUILD.gn
 @@ -12,11 +12,11 @@ toolchain("custom") {
    # these values in our scope.
    cc = "${toolchain_bin}/clang"
@@ -30,4 +30,3 @@ index 3da5f93026..05de4d7e3c 100644
    sysroot_flags = "--sysroot ${custom_sysroot}"
 -- 
 2.43.5
-

--- a/patches/flutter-engine/0001-clang-toolchain.patch
+++ b/patches/flutter-engine/0001-clang-toolchain.patch
@@ -1,17 +1,17 @@
-From eb564c8be13a16158056890069deef5bad533529 Mon Sep 17 00:00:00 2001
+From 5e4bf78183f9bf30d093b3e766f36a5780f068ab Mon Sep 17 00:00:00 2001
 From: Joel Winarske <joel.winarske@gmail.com>
-Date: Mon, 26 Aug 2024 12:25:58 -0700
+Date: Thu, 13 Feb 2025 12:44:11 -0800
 Subject: [PATCH] clang toolchain
 
 Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
 ---
- build/toolchain/custom/BUILD.gn | 8 ++++----
+ engine/src/build/toolchain/custom/BUILD.gn | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/build/toolchain/custom/BUILD.gn b/build/toolchain/custom/BUILD.gn
-index 3da5f93..05de4d7 100644
---- a/build/toolchain/custom/BUILD.gn
-+++ b/build/toolchain/custom/BUILD.gn
+diff --git a/engine/src/build/toolchain/custom/BUILD.gn b/engine/src/build/toolchain/custom/BUILD.gn
+index 3da5f93026..05de4d7e3c 100644
+--- a/engine/src/build/toolchain/custom/BUILD.gn
++++ b/engine/src/build/toolchain/custom/BUILD.gn
 @@ -12,11 +12,11 @@ toolchain("custom") {
    # these values in our scope.
    cc = "${toolchain_bin}/clang"
@@ -30,3 +30,4 @@ index 3da5f93..05de4d7 100644
    sysroot_flags = "--sysroot ${custom_sysroot}"
 -- 
 2.43.5
+

--- a/patches/flutter-engine/0002-fml-build-config-add-riscv.patch
+++ b/patches/flutter-engine/0002-fml-build-config-add-riscv.patch
@@ -1,0 +1,36 @@
+From 8b34fbdace418dcf338492ac63ce1048ecc20bf5 Mon Sep 17 00:00:00 2001
+From: Joel Winarske <joel.winarske@gmail.com>
+Date: Wed, 13 Mar 2024 21:28:43 +0000
+Subject: [PATCH] fml build config add riscv
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
+---
+ engine/src/flutter/fml/build_config.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/engine/src/flutter/fml/build_config.h b/fml/build_config.h
+index d42a88e..9ee6e04 100644
+--- a/engine/src/flutter/fml/build_config.h
++++ b/engine/src/flutter/fml/build_config.h
+@@ -93,6 +93,16 @@
+ #define FML_ARCH_CPU_ARM64 1
+ #define FML_ARCH_CPU_64_BITS 1
+ #define FML_ARCH_CPU_LITTLE_ENDIAN 1
++#elif defined(__riscv)
++#define FML_ARCH_CPU_RISC_FAMILY 1
++#if (__riscv_xlen == 32)
++#define FML_ARCH_CPU_RISCV32 1
++#define FML_ARCH_CPU_32_BITS 1
++#elif (__riscv_xlen == 64)
++#define FML_ARCH_CPU_RISCV64 1
++#define FML_ARCH_CPU_64_BITS 1
++#endif
++#define FML_ARCH_CPU_LITTLE_ENDIAN 1
+ #elif defined(__pnacl__)
+ #define FML_ARCH_CPU_32_BITS 1
+ #define FML_ARCH_CPU_LITTLE_ENDIAN 1
+-- 
+2.44.0
+

--- a/patches/flutter-engine/0003-gn-riscv32-and-riscv64.patch
+++ b/patches/flutter-engine/0003-gn-riscv32-and-riscv64.patch
@@ -1,0 +1,28 @@
+From 748e416e394552cac6e4be30112c3ef45d1c0ec3 Mon Sep 17 00:00:00 2001
+From: Joel Winarske <joel.winarske@gmail.com>
+Date: Tue, 6 Aug 2024 08:03:59 -0700
+Subject: [PATCH] gn riscv32 and riscv64
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
+---
+ engine/src/flutter/tools/gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/engine/src/flutter/tools/gn b/engine/src/flutter/tools/gn
+index 0be76e5477..8fee233aed 100755
+--- a/engine/src/flutter/tools/gn
++++ b/engine/src/flutter/tools/gn
+@@ -1015,7 +1015,7 @@ def parse_args(args):
+   parser.add_argument('--web', action='store_true', default=False)
+   parser.add_argument('--windows', dest='target_os', action='store_const', const='win')
+ 
+-  parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
++  parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm', 'riscv32', 'riscv64'])
+   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default='x64')
+   parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64', 'x86'], default='x64')
+   parser.add_argument('--simulator-cpu', type=str, choices=['x64', 'arm64'], default='x64')
+-- 
+2.45.2
+

--- a/patches/flutter-engine/0004-Add-risc-v-32-64-support-to-native-assets.patch
+++ b/patches/flutter-engine/0004-Add-risc-v-32-64-support-to-native-assets.patch
@@ -1,0 +1,30 @@
+From 8abe3d7d4aac9c33f4c59db85a7fb29cc7e31e69 Mon Sep 17 00:00:00 2001
+From: Joel Winarske <joel.winarske@gmail.com>
+Date: Tue, 8 Jul 2025 11:36:25 -0700
+Subject: [PATCH] Add risc-v 32/64 support to native assets
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
+---
+ engine/src/flutter/assets/native_assets.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/engine/src/flutter/assets/native_assets.cc b/engine/src/flutter/assets/native_assets.cc
+index afdf7ad..24a528d 100644
+--- a/engine/src/flutter/assets/native_assets.cc
++++ b/engine/src/flutter/assets/native_assets.cc
+@@ -17,6 +17,10 @@ namespace flutter {
+ #define kTargetArchitectureName "ia32"
+ #elif defined(FML_ARCH_CPU_X86_64)
+ #define kTargetArchitectureName "x64"
++#elif defined(FML_ARCH_CPU_RISCV32)
++#define kTargetArchitectureName "riscv32"
++#elif defined(FML_ARCH_CPU_RISCV64)
++#define kTargetArchitectureName "riscv64"
+ #else
+ #error Target architecture detection failed.
+ #endif
+-- 
+2.50.0
+

--- a/patches/flutter-engine/0005-tonic-riscv-support.patch
+++ b/patches/flutter-engine/0005-tonic-riscv-support.patch
@@ -1,0 +1,36 @@
+From 9be5e09115a693ab7fc8cee2122d0a4318fc6e71 Mon Sep 17 00:00:00 2001
+From: Joel Winarske <joel.winarske@gmail.com>
+Date: Sun, 4 Aug 2024 20:53:56 +0000
+Subject: [PATCH] tonic riscv support
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
+---
+ engine/src/flutter/third_party/tonic/common/build_config.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/engine/src/flutter/third_party/tonic/common/build_config.h b/engine/src/flutter/third_party/tonic/common/build_config.h
+index 365808a1a7..f3edb471be 100644
+--- a/engine/src/flutter/third_party/tonic/common/build_config.h
++++ b/engine/src/flutter/third_party/tonic/common/build_config.h
+@@ -88,6 +88,16 @@
+ #define ARCH_CPU_ARM64 1
+ #define ARCH_CPU_64_BITS 1
+ #define ARCH_CPU_LITTLE_ENDIAN 1
++#elif defined(__riscv)
++#define FML_ARCH_CPU_RISC_FAMILY 1
++#if (__riscv_xlen == 32)
++#define ARCH_CPU_RISCV32 1
++#define ARCH_CPU_32_BITS 1
++#elif (__riscv_xlen == 64)
++#define ARCH_CPU_RISCV64 1
++#define ARCH_CPU_64_BITS 1
++#endif
++#define ARCH_CPU_LITTLE_ENDIAN 1
+ #elif defined(__pnacl__)
+ #define ARCH_CPU_32_BITS 1
+ #define ARCH_CPU_LITTLE_ENDIAN 1
+-- 
+2.45.2
+


### PR DESCRIPTION
-rename flutter-engine to flutter-engine-deprecated -rename flutter-engine-mono to flutter-engine
-update riscv patches
-apply riscv patches for all build scenarios
 improve test milage
 enable future path of building flutter-engine directly on riscv64 machine