### PR TITLE
Cleanup and optimize CI workflows

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -6,45 +6,43 @@ on:
     paths-ignore:
       - .github/workflows/macos.yaml
       - .github/workflows/ubuntu.yml
+      - .github/workflows/ubuntu-legacy.yml
       - .github/workflows/windows.yaml
       - '**/*.md'
   release:
     types: [ published, created, edited ]
   workflow_dispatch:
   schedule:
-    # daily
-    - cron:  '0 0 * * *'
+    - cron: '0 4 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run:
     strategy:
+      fail-fast: false
       matrix:
         os: [fedora:41, fedora:42, fedora:43]
 
-    # NOTE: GitHub Actions does not support running on Fedora directly, so we run it in a container.
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.os }}
 
+    env:
+      CI: true
+      GITHUB_ACTIONS: true
+
     if: "!contains(github.event.pull_request.labels.*.name, 'ci: skip fedora') && !contains(github.event.head_commit.message, '[skip fedora]')"
 
     steps:
-      - name: Check Environment
-        run: |
-          echo "Running on Fedora version: $(cat /etc/fedora-release)"
-          echo "Running on architecture: $(uname -m)"
-          echo "Current directory: $(pwd)"
-          echo "Environment variables:"
-          env
-
       - name: Set up tools
         run: |
-          dnf install -y python3 python3-pip python3-pyyaml which cmake util-linux
-          python3 -m pip install --upgrade pip
+          dnf install -y python3 python3-pip python3-pyyaml which cmake util-linux sudo
 
       - name: Create non-root user
         run: |
-          dnf install -y sudo
           groupadd -g 1000 user
           useradd -m -u 1000 -g user -G wheel -s /bin/bash user
           echo "user ALL=(ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/user
@@ -52,26 +50,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create workspace
-        shell: bash
-        # Run as non-root user in the container
         run: |
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
-          chown -R user:user .
-          su - user -c "cd $GITHUB_WORKSPACE && pwd && ls -la && export CI=true && export GITHUB_ACTIONS=true && ./flutter_workspace.py --stdin-file=/dev/null"
-          cat ./setup_env.sh
+          chown -R user:user $GITHUB_WORKSPACE
+          su - user -c "cd $GITHUB_WORKSPACE && CI=true GITHUB_ACTIONS=true ./flutter_workspace.py --stdin-file=/dev/null"
 
       - name: Test workspace
-        shell: bash
         run: |
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
-          su - user -c "cd $GITHUB_WORKSPACE && pwd && ls -la && export CI=true && export GITHUB_ACTIONS=true && . ./setup_env.sh && dart --version"
+          su - user -c "cd $GITHUB_WORKSPACE && CI=true GITHUB_ACTIONS=true . ./setup_env.sh && dart --version"
 
       - name: Test AOT creation
-        working-directory: ${{ github.workspace }}
-        shell: bash
         run: |
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
-          su - user -c "cd $GITHUB_WORKSPACE && pwd && ls -la && export CI=true && export GITHUB_ACTIONS=true && . ./setup_env.sh && ./flutter_workspace.py --create-aot --app-path=./app/tcna-packages/packages/flatpak/example/"
+          su - user -c "cd $GITHUB_WORKSPACE && CI=true GITHUB_ACTIONS=true . ./setup_env.sh && ./flutter_workspace.py --create-aot --app-path=./app/tcna-packages/packages/flatpak/example/"

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -13,18 +13,24 @@ on:
     types: [ published, created, edited ]
   workflow_dispatch:
   schedule:
-    # daily
-    - cron:  '0 0 * * *'
+    - cron: '0 5 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
   run:
 
     env:
+      CI: true
+      GITHUB_ACTIONS: true
       NONINTERACTIVE: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ macos-14, macos-15 ]
 
@@ -34,44 +40,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - name: Check Environment
         run: |
-          echo "Running on macOS version: $(sw_vers -productVersion)"
-          echo "Running on architecture: $(uname -m)"
-          echo "Current directory: $(pwd)"
-          echo "Environment variables:"
-          env
-          
+          echo "macOS: $(sw_vers -productVersion)"
+          echo "Arch: $(uname -m)"
+
       - name: Brew fixup
         run: |
-          brew upgrade |true
-          brew cleanup |true
-          brew doctor |true
-          ruby -v
-          
+          brew cleanup || true
+          brew doctor || true
+
       - name: Create workspace
-        shell: bash
-        env:
-          CI: true
-          GITHUB_ACTIONS: true
-        run: |
-          env
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
-          ./flutter_workspace.py
-          cat ./setup_env.sh
+        run: ./flutter_workspace.py
 
       - name: Test workspace
-        shell: bash
-        env:
-          CI: true
-          GITHUB_ACTIONS: true
         run: |
-          env
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
           . ./setup_env.sh
           dart --version

--- a/.github/workflows/ubuntu-legacy.yml
+++ b/.github/workflows/ubuntu-legacy.yml
@@ -9,19 +9,24 @@ on:
       - .github/workflows/windows.yaml
       - .github/workflows/fedora.yml
       - .github/workflows/ubuntu.yml
+      - .github/workflows/ubuntu-legacy.yml
       - '**/*.md'
   release:
     types: [ published, created, edited ]
   workflow_dispatch:
   schedule:
-    # daily
-    - cron:  '0 0 * * *'
+    - cron: '0 3 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
   run:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu:20.04]
         llvm: [18, 14]
@@ -30,23 +35,18 @@ jobs:
     container:
       image: ${{ matrix.os }}
 
+    env:
+      CI: true
+      GITHUB_ACTIONS: true
+      DEBIAN_FRONTEND: noninteractive
+
     if: "!contains(github.event.pull_request.labels.*.name, 'ci: skip ubuntu-legacy') && !contains(github.event.head_commit.message, '[skip ubuntu-legacy]')"
 
     steps:
-      - name: Check Environment
-        run: |
-          echo "Running on Ubuntu version: $(lsb_release -d | cut -f2)"
-          echo "Running on architecture: $(uname -m)"
-          echo "Current directory: $(pwd)"
-          echo "Environment variables:"
-          env
-          
       - name: Set up tools
         run: |
           apt-get update -y
-          DEBIAN_FRONTEND=noninteractive apt-get install -yq python3 python3-pip bash cmake sudo
-          python3 -m pip install --upgrade pip
-          apt install python3.8-venv -yq
+          apt-get install -yq python3 python3-pip python3.8-venv bash cmake sudo
 
       - name: Create non-root user
         run: |
@@ -57,35 +57,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fix workspace permissions
-        shell: bash
-        run: |
-          cd $GITHUB_WORKSPACE
-          sudo chown -R user:user .
+        run: chown -R user:user $GITHUB_WORKSPACE
 
       - name: Create workspace
-        shell: bash
-        # Run as non-root user in the container
         run: |
-          env
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
-          export DEBIAN_FRONTEND=noninteractive; echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-          sudo -u user bash -c "./flutter_workspace.py"
-          cat ./setup_env.sh
+          echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+          sudo -u user bash -c "cd $GITHUB_WORKSPACE && ./flutter_workspace.py"
 
       - name: Test workspace
-        shell: bash
         run: |
-          env
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
-          sudo -u user bash -c ". ./setup_env.sh && dart --version"
+          sudo -u user bash -c "cd $GITHUB_WORKSPACE && . ./setup_env.sh && dart --version"
 
       - name: Create AOT Tests
-        shell: bash
         run: |
-          env
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
-          sudo -u user bash -c ". ./setup_env.sh && \
+          sudo -u user bash -c "cd $GITHUB_WORKSPACE && . ./setup_env.sh && \
           ./flutter_workspace.py --create-aot --app-path=./app/tcna-packages/packages/flatpak/example/"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,19 +13,22 @@ on:
     types: [ published, created, edited ]
   workflow_dispatch:
   schedule:
-    # daily
-    - cron:  '0 0 * * *'
+    - cron: '0 2 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
   run:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm]
         llvm: [18, 14]
         exclude:
-          # LLVM < 16 not supported for >= Ubuntu 24.04
           - os: ubuntu-24.04
             llvm: 14
           - os: ubuntu-24.04-arm
@@ -33,57 +36,36 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      CI: true
+      GITHUB_ACTIONS: true
+
     if: "!contains(github.event.pull_request.labels.*.name, 'ci: skip ubuntu') && !contains(github.event.head_commit.message, '[skip ubuntu]')"
 
     steps:
       - name: Check Environment
         run: |
-          echo "Running on Ubuntu version: $(lsb_release -d | cut -f2)"
-          echo "Running on architecture: $(uname -m)"
-          echo "Current directory: $(pwd)"
-          echo "Environment variables:"
-          env
+          echo "Ubuntu: $(lsb_release -d | cut -f2)"
+          echo "Arch: $(uname -m)"
 
       - uses: actions/checkout@v4
 
       - name: Create workspace
-        shell: bash
-        env:
-          CI: true
-          GITHUB_ACTIONS: true
-        # If llvm != 18, do --disable=toolchain-llvm-18
         run: |
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
           PREFER_LLVM=${{ matrix.llvm }} ./flutter_workspace.py
-          echo "Checking LLVM config..."
-          cat setup_env.sh; echo ""
           FOUND_LLVM_VER=$(grep -oP 'export PREFER_LLVM=\K[0-9]+' setup_env.sh)
-          if [ "$FOUND_LLVM_VER" != ${{ matrix.llvm }} ]; then
+          if [ "$FOUND_LLVM_VER" != "${{ matrix.llvm }}" ]; then
             echo "Expected LLVM version ${{ matrix.llvm }} but found ${FOUND_LLVM_VER} in setup_env.sh"
             exit 1
           fi
 
       - name: Test workspace
-        shell: bash
-        env:
-          CI: true
-          GITHUB_ACTIONS: true
         run: |
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
           . ./setup_env.sh
-          ls -la $FLUTTER_WORKSPACE
           dart --version
 
       - name: Create AOT Tests
         if: ${{ !contains(matrix.os, 'arm') }}
-        shell: bash
-        env:
-          CI: true
-          GITHUB_ACTIONS: true
         run: |
-          cd $GITHUB_WORKSPACE
-          pwd; ls -la
           . ./setup_env.sh
           ./flutter_workspace.py --create-aot --app-path=./app/tcna-packages/packages/flatpak/example/

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -13,18 +13,22 @@ on:
     types: [ published, created, edited ]
   workflow_dispatch:
   schedule:
-    # daily
-    - cron:  '0 0 * * *'
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
   run:
 
     env:
-      NONINTERACTIVE: 1
-      HOMEBREW_NO_AUTO_UPDATE: 1
+      CI: true
+      GITHUB_ACTIONS: true
 
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2022, windows-2025]
 
@@ -35,11 +39,8 @@ jobs:
     steps:
       - name: Check Environment
         run: |
-          echo "Running on Windows version: $(powershell -Command [System.Environment]::OSVersion.Version)"
-          echo "Running on architecture: $(uname -m)"
-          echo "Current directory: $(pwd)"
-          echo "Environment variables:"
-          env
+          echo "Windows: $(powershell -Command [System.Environment]::OSVersion.Version)"
+          echo "Arch: $(uname -m)"
 
       - uses: actions/checkout@v4
 
@@ -109,11 +110,8 @@ jobs:
 
       - name: Create workspace
         env:
-          CI: true
-          GITHUB_ACTIONS: true
           PIP_PREFER_BINARY: "1"
         run: |
-          Set-Location $env:GITHUB_WORKSPACE
           git config --global core.longpaths true
           python3.exe -m pip install --upgrade pip
           python3.exe -m pip install virtualenv
@@ -153,10 +151,6 @@ jobs:
           ./flutter_workspace.ps1
 
       - name: Test workspace
-        env:
-          CI: true
-          GITHUB_ACTIONS: true
         run: |
-          Set-Location $env:GITHUB_WORKSPACE
           & .\setup_env.ps1
           dart --version


### PR DESCRIPTION
Reduce CI runner waste and improve workflow reliability across all 5 GitHub Actions workflow files.

Concurrency & scheduling

- Add concurrency groups with cancel-in-progress: true to all workflows — stale runs are cancelled when new commits are pushed
- Add fail-fast: false to all matrix strategies — one failing matrix combination no longer cancels all sibling jobs
- Stagger daily cron schedules across workflows (02:00–06:00 UTC) to avoid runner contention

Noise reduction

- Remove redundant cd $GITHUB_WORKSPACE — GitHub Actions already sets the working directory
- Remove pwd; ls -la, env, and cat ./setup_env.sh debug dumps from all steps
- Trim Check Environment steps to OS version + architecture only

Per-workflow env consolidation

- Hoist CI: true and GITHUB_ACTIONS: true from per-step env: blocks to job-level env:
- Remove per-step shell: bash on Linux/macOS (already the default)

ubuntu.yml

- Remove redundant debug output from Create workspace step

ubuntu-legacy.yml

- Add self to paths-ignore (was missing)
- Consolidate DEBIAN_FRONTEND: noninteractive as job-level env var
- Remove unnecessary python3 -m pip install --upgrade pip (handled by workspace script)
- Merge sudo package install into Set up tools step

fedora.yml

- Add missing ubuntu-legacy.yml to paths-ignore
- Merge sudo install into Set up tools step
- Simplify su commands: use inline env vars (CI=true GITHUB_ACTIONS=true) instead of chained export statements
- Remove redundant working-directory directive combined with cd

macos.yaml

- Remove slow brew upgrade (unnecessary in CI, brew install handles updates)
- Remove fetch-depth: 1 (already the default)
- Remove ruby -v check (not relevant)

windows.yaml

- Remove irrelevant HOMEBREW_NO_AUTO_UPDATE and NONINTERACTIVE env vars
- Remove Set-Location $env:GITHUB_WORKSPACE (already the working directory)