### PR TITLE
[wayland-mesa] drop apt-file and full apt upgrade to speed up CI setup

### DIFF
--- a/configs/wayland-mesa.json
+++ b/configs/wayland-mesa.json
@@ -17,10 +17,9 @@
         "ubuntu": {
           "shell": true,
           "cmds": [
-            "sudo-apt-workspace install -yq lsb-release wget software-properties-common gnupg apt-file build-essential libtool",
+            "sudo-apt-workspace install -yq lsb-release wget software-properties-common gnupg build-essential libtool",
             "sudo add-apt-repository -y ppa:kisak/kisak-mesa", 
             "sudo-apt-workspace update -yq", 
-            "if [ \"$CI\" = \"true\" ]; then sudo-apt-workspace upgrade -yq --fix-missing || sudo-apt-workspace upgrade -yq -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" || echo 'Upgrade completed with some errors - continuing'; else sudo-apt-workspace upgrade -yq; fi", 
             "sudo-apt-workspace install -yq libxkbcommon-dev libwayland-dev wayland-protocols mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libsecret-1-dev libsdl2-dev libjpeg-dev zenity"
           ]
         },
@@ -37,10 +36,9 @@
         "ubuntu": {
           "shell": true,
           "cmds": [
-            "sudo-apt-workspace install -yq lsb-release wget software-properties-common gnupg apt-file build-essential libtool",
+            "sudo-apt-workspace install -yq lsb-release wget software-properties-common gnupg build-essential libtool",
             "sudo add-apt-repository -y ppa:kisak/kisak-mesa", 
             "sudo-apt-workspace update -yq", 
-            "if [ \"$CI\" = \"true\" ]; then sudo-apt-workspace upgrade -yq --fix-missing || sudo-apt-workspace upgrade -yq -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" || echo 'Upgrade completed with some errors - continuing'; else sudo-apt-workspace upgrade -yq; fi", 
             "sudo-apt-workspace install -yq libxkbcommon-dev libwayland-dev wayland-protocols mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libsecret-1-dev libsdl2-dev libjpeg-dev zenity"
           ]
         },


### PR DESCRIPTION
Addresses item 1 of #180 — the biggest avoidable cost in the crash-handler / wayland-mesa setup.

## Change
`configs/wayland-mesa.json` ubuntu pre-requisites (both arch blocks):
- **Remove `apt-file`** from the install list. It is never used, but installing it makes the following `apt update` also download the package **Contents** indices — ~640 MB on jammy (`jammy-updates` 299 MB + `jammy-security` 291 MB).
- **Remove the full `apt upgrade`** (dist-upgrade of an already-current GitHub-hosted runner image). The named dev packages install fine against the base indices.

Kept the `kisak-mesa` PPA so the Mesa version is unchanged for jobs that actually run graphics.

## Impact
Several minutes off every job that loads the `wayland-mesa` dependency. For ivi-homescreen's `crash-handler` (~11 min, ~5 of which was apt setup) this is the dominant lever — downstream caching only helps toolchain/sentry, not the apt step.

## Risk
Low: `apt-file` removal is inert (nothing uses it); dropping `apt upgrade` only skips upgrading packages the build doesn't pin. No package the configs install is removed.

Refs #180.