### PR TITLE
Fix Fedora dep install upgrading python3 under running interpreter

### DIFF
--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -2893,7 +2893,11 @@ def install_minimum_runtime_deps():
             subprocess.check_output(packages)
 
         elif os_release_id == 'fedora':
-            subprocess.check_output(['sudo', 'dnf', '-y', 'update'])
+            # Refresh metadata only (equivalent of `apt update`). A full
+            # `dnf update` would upgrade every package -- including python3 --
+            # out from under this still-running interpreter, causing a C API
+            # version mismatch crash on the next lazy import.
+            subprocess.check_output(['sudo', 'dnf', '-y', 'makecache'])
             packages = 'sudo dnf -y install dnf-plugins-core git git-lfs unzip curl python3-devel python3-virtualenv libcurl-devel openssl-devel gtk3-devel gcc libcurl-devel'.split(
                 ' ')
             subprocess.check_output(packages)


### PR DESCRIPTION
# Summary

 \`install_minimum_runtime_deps()\` ran \`dnf -y update\`, which upgrades every installed package -- including python3 -- while this script's interpreter is still running. That can swap out the C API version mid-run and crash on the next lazy import.

This replaces it with \`dnf -y makecache\`, which only refreshes repository metadata (the equivalent of \`apt update\`) without touching installed packages.

 ## Test plan

- [x] Run \`flutter_workspace.py\` on Fedora and confirm dependency install completes without the interpreter crashing.