### PR TITLE
Fixes CI caching flags & repo sync

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -147,7 +147,7 @@ runs:
       # Compute the cache path and key once so both restore and save steps
       # reference identical values.
       - name: Compute cache configuration
-        if: ${{ inputs.cache }}
+        if: ${{ inputs.cache == 'true' || inputs.cache-whole == 'true' }}
         id: cache-cfg
         shell: bash
         run: |
@@ -165,7 +165,7 @@ runs:
           echo "restore-keys=${BASE_KEY}-" >> "$GITHUB_OUTPUT"
 
       - name: Cache status
-        if: ${{ inputs.cache }}
+        if: ${{ inputs.cache == 'true' || inputs.cache-whole == 'true' }}
         shell: bash
         run: |
           echo "Cache enabled: ${{ inputs.cache }}"
@@ -179,7 +179,7 @@ runs:
 
       #  Cache restore
       - name: Restore workspace cache
-        if: ${{ inputs.cache }}
+        if: ${{ inputs.cache == 'true' || inputs.cache-whole == 'true' }}
         id: cache-restore
         uses: actions/cache/restore@v4
         with:
@@ -187,7 +187,7 @@ runs:
           key: ${{ steps.cache-cfg.outputs.key }}
 
       - name: Fix cache permissions
-        if: ${{ inputs.cache && steps.cache-restore.outputs.cache-hit == 'true' }}
+        if: ${{ inputs.cache == 'true' || inputs.cache-whole == 'true' }}
         shell: bash
         env:
           USER: ${{ steps.os-check.outputs.user }}
@@ -252,7 +252,7 @@ runs:
       # even when post-setup-cmd fails. Skipped only when caching is
       # disabled or the key was already an exact hit (nothing new to store).
       - name: Save workspace cache
-        if: ${{ inputs.cache }}
+        if: ${{ inputs.cache == 'true' || inputs.cache-whole == 'true' && steps.cache-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.cache-cfg.outputs.path }}

--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -1008,6 +1008,18 @@ def cache_mirror_repo(source_git_folder, dest_name):
         subprocess.check_call(cmd)
 
 
+def sync_repo_from_remote(git_folder, branch=None):
+    """Fetch from remote and pull latest changes (fast-forward only)."""
+    subprocess.check_call(['git', 'fetch', '--all'], cwd=git_folder)
+    cmd = ['git', 'pull', '--ff-only']
+    if branch:
+        cmd.extend(['origin', branch])
+    try:
+        subprocess.check_call(cmd, cwd=git_folder)
+    except subprocess.CalledProcessError:
+        print(f"WARNING: git pull failed, continuing anyway")
+
+
 def get_repo(base_folder, uri, ref, branch=None, dest_name=None):
     """ Clone Git Repo """
     if not uri:
@@ -1048,15 +1060,7 @@ def get_repo(base_folder, uri, ref, branch=None, dest_name=None):
     if os.path.exists(git_hidden_folder):
         # re-run: repo already present — update in-place
         subprocess.check_call(['git', 'reset', '--hard'], cwd=git_folder)
-        subprocess.check_call(['git', 'fetch', '--all'], cwd=git_folder)
-        cmd = ['git', 'pull', '--ff-only']
-        if branch:
-            print(f'Using branch: {branch}')
-            cmd.extend(['origin', branch])
-        try:
-            subprocess.check_call(cmd, cwd=git_folder)
-        except subprocess.CalledProcessError:
-            print(f"WARNING: git pull failed, continuing anyway")
+        sync_repo_from_remote(git_folder, branch)
 
     elif cache_exists:
         # restore full working tree (includes LFS objects and submodule content)
@@ -1064,6 +1068,7 @@ def get_repo(base_folder, uri, ref, branch=None, dest_name=None):
         if os.path.exists(git_folder):
             shutil.rmtree(git_folder)
         shutil.copytree(cache_dir, git_folder, symlinks=True)
+        sync_repo_from_remote(git_folder, branch)
         restored_from_cache = True
 
     else:
@@ -1083,6 +1088,9 @@ def get_repo(base_folder, uri, ref, branch=None, dest_name=None):
     elif branch:
         print(f'git checkout {branch}')
         subprocess.check_call(['git', 'checkout', branch], cwd=git_folder)
+        if restored_from_cache:
+            # In case the upstream branch has been force-pushed to, reset to the latest commit on the remote branch
+            subprocess.check_call(['git', 'reset', '--hard', f'origin/{branch}'], cwd=git_folder)
 
     if os.path.exists(os.path.join(git_folder, '.gitattributes')):
         subprocess.check_call(['git', 'lfs', 'fetch', '--all'], cwd=git_folder)


### PR DESCRIPTION
This PR addresses two issues related to caching:

- Fixes a bug in the Setup Flutter Workspace GitHub Action where the [cache](vscode-file://vscode-app/usr/share/code-insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html) parameter was always evaluated as true.
- Fixes an issue where repositories restored from cache were not being updated with the latest changes from remote.