### PR TITLE
Add Westeros 2.1.1 build config

### DIFF
--- a/configs/westeros_2.1.1.json
+++ b/configs/westeros_2.1.1.json
@@ -1,0 +1,92 @@
+{
+    "id": "westeros",
+    "load": false,
+    "supported_archs": [
+        "aarch64",
+        "arm64",
+        "x86_64"
+    ],
+    "supported_host_types": [
+        "ubuntu",
+        "fedora"
+    ],
+    "type": "dependency",
+    "env": {
+        "PATH": "${FLUTTER_WORKSPACE}/.config/flutter_workspace/toolchain-common-ninja:${FLUTTER_WORKSPACE}/.config/flutter_workspace/toolchain-common-cmake/bin:$PATH",
+        "WESTEROS_SRC_DIR": "${FLUTTER_WORKSPACE}/app/westeros-2.1.1",
+        "WESTEROS_STAGING_DIR": "${FLUTTER_WORKSPACE}/app/westeros-2.1.1/external/install",
+        "SCANNER_TOOL": "wayland-scanner",
+        "PKG_CONFIG_PATH": "${FLUTTER_WORKSPACE}/app/westeros-2.1.1/external/install/lib/pkgconfig:${FLUTTER_WORKSPACE}/app/westeros-2.1.1/external/install/share/pkgconfig:$PKG_CONFIG_PATH",
+        "WESTEROS_CONFIG_ARGS": "--enable-xdgv5 --enable-rendergl --enable-app --enable-test --enable-embedded=no --enable-essos=no",
+        "WESTEROS_STAGING_FLAGS": "CPPFLAGS=-I${FLUTTER_WORKSPACE}/app/westeros-2.1.1/external/install/include LDFLAGS=-L${FLUTTER_WORKSPACE}/app/westeros-2.1.1/external/install/lib"
+    },
+    "src": [
+        {
+            "uri": "https://github.com/rdkcentral/westeros.git",
+            "rev": "cb69ee87acf80ee98ef9b62eb39454ef99bd612a",
+            "dest_name": "westeros-2.1.1"
+        }
+    ],
+    "runtime": {
+        "pre-requisites": {
+            "aarch64": {
+                "ubuntu": {
+                    "cmds": [
+                        "sudo apt-get install -yq build-essential autoconf automake libtool pkg-config libwayland-bin libwayland-dev wayland-protocols libxkbcommon-dev libxcb1-dev libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev libglew-dev freeglut3-dev libx11-dev libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev"
+                    ]
+                }
+            },
+            "x86_64": {
+                "ubuntu": {
+                    "cmds": [
+                        "sudo apt-get install -yq build-essential autoconf automake libtool pkg-config libwayland-bin libwayland-dev wayland-protocols libxkbcommon-dev libxcb1-dev libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev libglew-dev freeglut3-dev libx11-dev libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev"
+                    ]
+                },
+                "fedora": {
+                    "cmds": [
+                        "sudo dnf install -y autoconf automake libtool pkgconf-pkg-config wayland-devel wayland-protocols-devel libxkbcommon-devel libxcb-devel mesa-libEGL-devel mesa-libGLES-devel mesa-libGL-devel glew-devel freeglut-devel libX11-devel glib2-devel gstreamer1-devel gstreamer1-plugins-base-devel"
+                    ]
+                }
+            }
+        },
+        "post_cmds": [
+            {
+                "cwd": "${WESTEROS_SRC_DIR}",
+                "cmds": [
+                    "bash -c \"rm -rf ${WESTEROS_STAGING_DIR} | true\"",
+                    "mkdir -p ${WESTEROS_STAGING_DIR}",
+                    "make -C protocol",
+                    "make -C simpleshell/protocol"
+                ]
+            },
+            {
+                "cwd": "${WESTEROS_SRC_DIR}/simpleshell",
+                "cmds": [
+                    "mkdir -p m4",
+                    "autoreconf -fi",
+                    "./configure --prefix ${WESTEROS_STAGING_DIR}",
+                    "make",
+                    "make install"
+                ]
+            },
+            {
+                "cwd": "${WESTEROS_SRC_DIR}",
+                "cmds": [
+                    "mkdir -p m4",
+                    "autoreconf -fi",
+                    "./configure --prefix ${WESTEROS_STAGING_DIR} ${WESTEROS_CONFIG_ARGS} ${WESTEROS_STAGING_FLAGS}",
+                    "make",
+                    "make install"
+                ]
+            }
+        ],
+        "do_clean": [
+            {
+                "cwd": "${WESTEROS_SRC_DIR}",
+                "cmds": [
+                    "make clean"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
# Add Westeros 2.1.1 build config

## Summary

Adds `configs/westeros_2.1.1.json` so the workspace can build the [RDK Westeros](https://github.com/rdkcentral/westeros) Wayland compositor library (tag `2.1.1`, commit `cb69ee87`) from source as a dependency. Enable it with `--enable=westeros`.

The config follows upstream's `Makefile.ubuntu` flow but replaces its dead `git://anongit.freedesktop.org` externals and Wayland 1.6.0 build with system-provided libraries, and modernizes the autotools invocation for current toolchains.

## What it does

- **Source**: pins by `rev` with `dest_name: westeros-2.1.1` → clones into `app/westeros-2.1.1`. No `branch` is set so the clone uses the repo's default branch (`develop`); the tagged commit is reachable from there (the repo has no `master`).
- **Dependencies**: installs Wayland / xkbcommon / EGL / GLES / GL / GLEW / freeglut / X11 / GLib / GStreamer dev packages for Fedora and Ubuntu instead of building externals from source.
- **Build**: generates the bundled xdg-shell + simpleshell protocols → builds and installs `simpleshell` into a staging prefix → builds `westeros-core` with `--enable-xdgv5 --enable-rendergl --enable-app --enable-test`.

## Notable fixes vs. upstream Makefile.ubuntu

- Drives autotools with `autoreconf -fi` (macro dir is `m4`; upstream's `aclocal -I cfg` is stale and fails).
- Passes staging `CPPFLAGS`/`LDFLAGS` to the core `configure` so it finds the installed `westeros-simpleshell.h` / lib.
- Adds `freeglut`/`GLEW`/`libGL`/`libX11` dev packages required by the rendergl, render-embedded, app, and test targets.

## Testing

- ✅ Clone + checkout of tag `2.1.1` into `app/westeros-2.1.1`
- ✅ Protocol generation (xdg-shell v4/v5/stable, vpc, simpleshell)
- ✅ `simpleshell` configure + build + install
- ✅ `westeros-core` configure + compile through to final link
- ⏳ Verified on Fedora 43 / x86_64; Ubuntu and aarch64 not yet exercised
