### PR TITLE
Fixed repos not being cloned

### DIFF
--- a/flutter_workspace.py
+++ b/flutter_workspace.py
@@ -487,7 +487,13 @@ def main():
     if not is_exist:
         os.makedirs(app_folder)
 
-    get_workspace_repos(app_folder, configs)
+    # Construct config dict for get_workspace_repos
+    # It expects {'repos': [...], 'platforms': [...]}
+    workspace_config = {
+        'repos': globals_.get('repos', []),
+        'platforms': configs
+    }
+    get_workspace_repos(app_folder, workspace_config)
 
     #
     # Prepend depot_tools to PATH
@@ -757,9 +763,20 @@ def load_configs(config_dir: Path, flutter_version_override: str = '', enable: s
     enable_list = enable.split(',') if enable else []
     disable_list = disable.split(',') if disable else []
 
+    # Load repos.json if it exists and store in globals_config
+    repos_path = config_dir / "repos.json"
+    if repos_path.exists():
+        print(f"Loading repos config: {repos_path}")
+        repos_data = load_json_config(repos_path)
+        if isinstance(repos_data, list):
+            globals_config['repos'] = repos_data
+        else:
+            print(f"WARNING: {repos_path} did not load as a list, skipping")
+    else:
+        print(f"WARNING: repos.json not found at {repos_path}, proceeding without it")
+
     # Files to skip (not platform configs)
     skip_files = {'globals.json', 'repos.json'}
-
     # Load all platform config files (excluding globals.json and repos.json)
     configs = []
     for config_file in sorted(config_dir.glob("*.json")):
@@ -1170,6 +1187,8 @@ def get_workspace_repos(base_folder, config):
     import concurrent.futures
 
     if 'repos' not in config:
+        # print warning
+        print_banner("No `configs/repos.json` file found, skipping repo clone")
         return
 
     repos = config['repos']


### PR DESCRIPTION
## Bug Investigation Summary

**Root Cause:**
The `repos.json` configuration file was never being loaded into the workspace configuration. This happened because:

1. `load_configs()` explicitly excluded `repos.json` from processing (line 759)
2. `get_workspace_repos()` expected a dictionary with a 'repos' key, but received a list of platform configs
3. This caused the function to return early without cloning any repositories

**Changes Made:**

1. **Modified `load_configs()` function:**
   - Now loads `repos.json` if it exists
   - Stores the repos data in `globals_config['repos']`

2. **Modified the call to `get_workspace_repos()` in `main()`:**
   - Constructs a proper config dictionary with both 'repos' and 'platforms' keys
   - Passes this structure to `get_workspace_repos()`

**Verification:**
- The code changes are syntactically correct
- The logic flow now properly loads and passes the repos configuration
- All pre-existing errors in the file are unrelated to these changes

The fix ensures that `repos.json` is properly loaded and all repositories defined in it will be cloned during workspace setup.